### PR TITLE
speech duration calculation bug for local transcription

### DIFF
--- a/openwillis/measures/text/util/characteristics_util.py
+++ b/openwillis/measures/text/util/characteristics_util.py
@@ -901,7 +901,12 @@ def update_summ_df(
 
     ------------------------------------------------------------------------------------------------------
     """
-    summ_df[measures["speech_minutes"]] = [phrase_df[measures["phrase_minutes"]].sum()]
+    if len(phrase_df) > 0:
+        summ_df[measures["speech_minutes"]] = [phrase_df[measures["phrase_minutes"]].sum()]
+    else:
+        summ_df[measures["speech_minutes"]] = [
+            (float(df_diff.iloc[-1][time_index[1]]) - float(df_diff.iloc[0][time_index[0]])) / 60
+        ]
 
     summ_df[measures["speech_words"]] = len(df_diff)
     if len(df_diff) > 0:


### PR DESCRIPTION
Change calculation for speech duration, if transcription local i.e. if phrase_df does not exist