### PR TITLE
Downgrade vosk to 0.3.44

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ protobuf3-to-dict==0.1.5
 praat-parselmouth==0.4.3
 pydub==0.25.1
 deepface==0.0.75
-vosk==0.3.45
+vosk==0.3.44
 vaderSentiment==3.3.2
 nltk==3.8.1
 lexicalrichness==0.5.0


### PR DESCRIPTION
Solve mac with intel chip issue on installing vosk. Referenced here: #84 