### PR TITLE
Remove warnings at import

### DIFF
--- a/openwillis/measures/audio/speech_separation_nlabels.py
+++ b/openwillis/measures/audio/speech_separation_nlabels.py
@@ -2,6 +2,12 @@
 # website:   http://www.bklynhlth.com
 
 # import the required packages
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger=logging.getLogger()
+logging.getLogger('torch.distributed.nn.jit.instantiator').setLevel(logging.WARNING)
+
 from pyannote.audio import Pipeline
 from openwillis.measures.audio.util import separation_util as sutil
 from pydub import AudioSegment
@@ -9,10 +15,6 @@ from pydub import AudioSegment
 import os
 import json
 import pandas as pd
-import logging
-
-logging.basicConfig(level=logging.INFO)
-logger=logging.getLogger()
 
 def get_config():
     """

--- a/openwillis/measures/audio/util/disvoice_util.py
+++ b/openwillis/measures/audio/util/disvoice_util.py
@@ -6,14 +6,28 @@ and are modified for efficiency and speed
 # website:   http://www.bklynhlth.com
 
 import sys
+import os
 
 import numpy as np
 from scipy.io.wavfile import read
 from scipy.integrate import cumtrapz
 from scipy.signal import find_peaks
 
-from disvoice.glottal.GCI import iaif, compute_h1h2_hrf_frame, find_amid_t
-from disvoice.glottal.utils_gci import create_continuous_smooth_f0, GetLPCresidual, get_MBS, get_MBS_GCI_intervals, search_res_interval_peaks
+# Backup the original stderr
+original_stderr = sys.stderr
+
+try:
+    # Redirect stderr to null
+    sys.stderr = open(os.devnull, 'w')
+
+    # Import the packages that cause the warning
+    from disvoice.glottal.GCI import iaif, compute_h1h2_hrf_frame, find_amid_t
+    from disvoice.glottal.utils_gci import create_continuous_smooth_f0, GetLPCresidual, get_MBS, get_MBS_GCI_intervals, search_res_interval_peaks
+
+finally:
+    # Restore the original stderr
+    sys.stderr.close()
+    sys.stderr = original_stderr
 import pysptk
 
 


### PR DESCRIPTION
DisVoice and Torch packages can cause warnings at import that don't offer any needed information, so we mute them