### PR TITLE
WhisperX compute_type when device is CUDA

### DIFF
--- a/openwillis/measures/audio/util/whisperx_util.py
+++ b/openwillis/measures/audio/util/whisperx_util.py
@@ -161,8 +161,9 @@ def get_whisperx_diariazation(filepath, input_param):
     try:
         if torch.cuda.is_available():
             device = 'cuda'
-            compute_type = "float16"
-    
+            if not compute_type.startswith('float'):
+                compute_type = "float16"
+
         transcribe_json, audio = transcribe_whisper(filepath, input_param['model'], device, compute_type, input_param['batch_size'], input_param['infra_model'], input_param['language'])
     
         # Align whisper output

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("requirements.txt", "r") as fp:
     install_requires = fp.read()
 
 setuptools.setup(name='openwillis',
-                 version='2.2.2',
+                 version='2.2.3',
                  description='digital health measurement',
                  long_description=long_description,
                  long_description_content_type="text/markdown",


### PR DESCRIPTION
Add ability to edit `compute_type` in WhisperX transcription when device is CUDA and type is `float`