### PR TITLE
Bug with single speaker speech characteristics analysis

### DIFF
--- a/openwillis/measures/audio/speech_transcribe_cloud.py
+++ b/openwillis/measures/audio/speech_transcribe_cloud.py
@@ -120,6 +120,9 @@ def speech_transcription_aws(s3_uri, **kwargs):
 
     present_labels = [x['speaker_label'] for x in json_response['results']['items'] if 'speaker_label' in x]
     if len(set(present_labels)) != 2:
+        if input_param['speaker_labels'] == True and input_param['max_speakers'] == 1:
+            for item in json_response['results']['items']:
+                item['speaker_label'] = 'speaker_0'
         return json_response, transcript, willisdiarize_status
 
     if input_param['language'].lower()[:2] == 'en' and input_param['willisdiarize_endpoint'].lower() not in ['', 'none']:

--- a/openwillis/measures/text/util/characteristics_util.py
+++ b/openwillis/measures/text/util/characteristics_util.py
@@ -491,8 +491,8 @@ def create_text_list(utterances_speaker, speaker_label, min_turn_length, measure
     word_list = sum(utterances_speaker[measures['words_texts']].tolist(), [])
 
     valid_turns = utterances_speaker[utterances_speaker[measures['words_texts']].apply(len) >= min_turn_length]
-    turn_list = valid_turns[measures['utterance_text']].tolist()
-    turn_indices = valid_turns[measures['utterance_ids']].tolist()
+    turn_list = valid_turns[measures['utterance_text']].tolist() if speaker_label is not None else []
+    turn_indices = valid_turns[measures['utterance_ids']].tolist() if speaker_label is not None else []
 
     text_list = [word_list, turn_list, full_text]
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("requirements.txt", "r") as fp:
     install_requires = fp.read()
 
 setuptools.setup(name='openwillis',
-                 version='2.3.0',
+                 version='2.3.1',
                  description='digital health measurement',
                  long_description=long_description,
                  long_description_content_type="text/markdown",


### PR DESCRIPTION
Bug when processing files with 1 speaker for speech characteristics in purpose.

* Artificially add speaker label if `max_speakers` is set to 1 in `speech_transcription_aws`
* Do not process turn measures, if `speaker_label` is set to `None`