### PR TITLE
Add Brunet’s Index and Honoré’s Statistic for Lexical Diversity Measurement

### DIFF
--- a/openwillis-speech/src/openwillis/speech/config/text.json
+++ b/openwillis-speech/src/openwillis/speech/config/text.json
@@ -15,6 +15,8 @@
   "speech_mattr_25": "mattr_25",
   "speech_mattr_50": "mattr_50",
   "speech_mattr_100": "mattr_100",
+  "brunet_index": "brunet_index",
+  "honore_statistic": "honore_statistic",
   "rate_of_speech": "rate_of_speech",
   "pause_meandur": "mean_pause_length",
   "pause_var": "pause_variability",

--- a/openwillis-speech/src/openwillis/speech/util/characteristics_util.py
+++ b/openwillis-speech/src/openwillis/speech/util/characteristics_util.py
@@ -1,16 +1,17 @@
 # author:    Vijay Yadav, Georgios Efstathiadis
 # website:   http://www.bklynhlth.com
 
+import itertools
 # import the required packages
 import logging
-import itertools
 
-import pandas as pd
-import numpy as np
 import nltk
+import numpy as np
+import pandas as pd
+
+from .speech.coherence import get_phrase_coherence, get_word_coherence
+from .speech.lexical import get_pos_tag, get_repetitions, get_sentiment
 from .speech.pause import get_pause_feature
-from .speech.lexical import get_repetitions, get_sentiment, get_pos_tag
-from .speech.coherence import get_word_coherence, get_phrase_coherence
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger()
@@ -70,6 +71,7 @@ def create_empty_dataframes(measures):
                                     measures["pause_meandur"], measures["pause_var"], measures["pos"], measures["neg"], 
                                     measures["neu"], measures["compound"], measures["speech_mattr_5"],
                                     measures["speech_mattr_10"], measures["speech_mattr_25"], measures["speech_mattr_50"], measures["speech_mattr_100"],
+                                    measures["honore_statistic"], measures["brunet_index"],
                                     measures["first_person_percentage"], measures["first_person_sentiment_positive"], measures["first_person_sentiment_negative"],
                                     measures["word_repeat_percentage"], measures["phrase_repeat_percentage"],
                                     measures["sentence_tangeniality1"], measures["sentence_tangeniality2"],
@@ -82,6 +84,7 @@ def create_empty_dataframes(measures):
                 measures["syllable_rate"], measures["word_pause_mean"], measures["word_pause_var"], 
                 measures["speech_percentage"], measures["pos"], measures["neg"], measures["neu"], measures["compound"],
                 measures["speech_mattr_5"], measures["speech_mattr_10"], measures["speech_mattr_25"], measures["speech_mattr_50"], measures["speech_mattr_100"],
+                measures['honore_statistic'], measures['brunet_index'],
                 measures["first_person_percentage"], measures["first_person_sentiment_positive"],
                 measures["first_person_sentiment_negative"], measures["first_person_sentiment_overall"],
                 measures["word_repeat_percentage"], measures["phrase_repeat_percentage"],

--- a/openwillis-speech/src/openwillis/speech/util/speech/lexical.py
+++ b/openwillis-speech/src/openwillis/speech/util/speech/lexical.py
@@ -416,7 +416,6 @@ def get_sentiment(df_list, text_list, measures):
         lemmatizer = spacy.load('en_core_web_sm')
 
         sentiment = SentimentIntensityAnalyzer()
-        #cols = [measures["neg"], measures["neu" ], measures["pos"], measures["compound"], measures["speech_mattr_5"], measures["speech_mattr_10"], measures["speech_mattr_25"], measures["speech_mattr_50"], measures["speech_mattr_100"]]
         cols = [measures["neg"], measures["neu"], measures["pos"], measures["compound"], measures["speech_mattr_5"], measures["speech_mattr_10"], measures["speech_mattr_25"], measures["speech_mattr_50"], measures["speech_mattr_100"], measures["brunet_index"], measures["honore_statistic"]]
 
         for idx, u in enumerate(turn_list):


### PR DESCRIPTION
This PR adds two new metrics for lexical diversity:

- Brunet’s Index
- Honoré’s Statistic

These are length-robust global measures that complement existing moving-average type-token ratios (MATTRs) by characterizing vocabulary richness at the sample level (as opposed to fixed window). In particular, Honoré’s statistic accounts for the presence of hapax legomena (words occurring only once), offering an additional dimension of lexical variability.

Code has been added to the 'lexical.py' module and evaluated on the CLEAR corpus via exploratory notebook analysis (not included in this PR).

All changes are additive.
