### PR TITLE
Fix missing BLSTM model and bump to 3.2.2

### DIFF
--- a/openwillis-face/setup.py
+++ b/openwillis-face/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt", "r") as fp:
 
 setup(
     name='openwillis-face',
-    version='1.1.1',
+    version='1.1.2',
     description='digital health measurement',
     long_description_content_type="text/markdown",
     url='https://github.com/bklynhlth/openwillis',

--- a/openwillis-gps/setup.py
+++ b/openwillis-gps/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt", "r") as fp:
 
 setup(
     name='openwillis-gps',
-    version='1.1.1',
+    version='1.1.2',
     description='digital health measurement',
     long_description_content_type="text/markdown",
     url='https://github.com/bklynhlth/openwillis',

--- a/openwillis-speech/requirements.txt
+++ b/openwillis-speech/requirements.txt
@@ -3,7 +3,6 @@ vaderSentiment==3.3.2
 nltk==3.9.1
 lexicalrichness==0.5.1
 pandas==2.2.3
-pytest==8.3.4
 transformers==4.46.3
 sentence-transformers==3.3.1
 huggingface-hub==0.26.3

--- a/openwillis-speech/setup.py
+++ b/openwillis-speech/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt", "r") as fp:
 
 setup(
     name='openwillis-speech',
-    version='1.1.1',
+    version='1.1.2',
     description='digital health measurement',
     long_description_content_type="text/markdown",
     url='https://github.com/bklynhlth/openwillis',

--- a/openwillis-transcribe/setup.py
+++ b/openwillis-transcribe/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt", "r") as fp:
 
 setup(
     name='openwillis-transcribe',
-    version='1.1.1',
+    version='1.1.2',
     description='digital health measurement',
     long_description_content_type="text/markdown",
     url='https://github.com/bklynhlth/openwillis',

--- a/openwillis-voice/MANIFEST.in
+++ b/openwillis-voice/MANIFEST.in
@@ -8,3 +8,4 @@ include src/openwillis/voice/util/praat_tremor/procedures/readPitchOb.praat
 include src/openwillis/voice/util/praat_tremor/procedures/tremHNR.praat
 include src/openwillis/voice/util/praat_tremor/procedures/tremIntIndex.praat
 include src/openwillis/voice/util/praat_tremor/procedures/tremProdSum.praat
+include src/openwillis/voice/util/models/BLSTM_model.h5

--- a/openwillis-voice/setup.py
+++ b/openwillis-voice/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt", "r") as fp:
 
 setup(
     name='openwillis-voice',
-    version='1.1.1',
+    version='1.1.2',
     description='digital health measurement',
     long_description_content_type="text/markdown",
     url='https://github.com/bklynhlth/openwillis',

--- a/openwillis/setup.py
+++ b/openwillis/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='openwillis',
-    version='3.2.1',
+    version='3.2.2',
     description='digital health measurement',
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -18,10 +18,10 @@ setup(
     author_email='admin@bklynhlth.com',
     license='Apache',
     install_requires=[
-        'openwillis-voice==1.1.1',
-        'openwillis-transcribe==1.1.1',
-        'openwillis-gps==1.1.1',
-        'openwillis-speech==1.1.1',
-        'openwillis-face==1.1.1',
+        'openwillis-voice==1.1.2',
+        'openwillis-transcribe==1.1.2',
+        'openwillis-gps==1.1.2',
+        'openwillis-speech==1.1.2',
+        'openwillis-face==1.1.2',
     ],
 )


### PR DESCRIPTION
- Include BLSTM_model.h5 in openwillis-voice MANIFEST.in (was missing from pip package)
- Remove pytest from openwillis-speech install dependencies
- Bump all subpackages to 1.1.2, meta-package to 3.2.2