### PR TITLE
Add tensorflow/tf-keras to openwillis-voice so the package imports after pip install

### DIFF
--- a/openwillis-voice/requirements.txt
+++ b/openwillis-voice/requirements.txt
@@ -10,3 +10,5 @@ speechbrain==1.0.2
 torch>=2.5.1,<2.6
 torchaudio>=2.5.1,<2.6
 transformers==4.46.3
+tensorflow==2.15.1
+tf-keras==2.15.1


### PR DESCRIPTION
This PR proposes declaring the missing `tensorflow` / `tf-keras` dependency of `openwillis-voice`, so that `import openwillis.voice` works after a fresh `pip install`. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/329. You can sign in with your GitHub ID to claim ownership of the project.

### The defect

`openwillis/voice/util/coordination_util.py` imports `from tensorflow.keras.models import load_model` (it loads the BLSTM articulation-coordination model). That module is imported unconditionally at package-import time: `openwillis/voice/__init__.py` imports `acoustic.py`, and `acoustic.py` does `from .util import coordination_util as cutil` at the top level. So `tensorflow.keras` is on the `import openwillis.voice` code path.

However `openwillis-voice/requirements.txt` (which becomes `install_requires`) declares neither `tensorflow` nor `tf-keras`, and none of the other declared dependencies (`disvoice`, `speechbrain`, `librosa`, `transformers`, `torch`, `torchaudio`, `praat-parselmouth`, `pydub`, `scipy`) pull them in transitively. A fresh `pip install openwillis-voice` therefore installs an unimportable package. This is the natural follow-up to the recent "Fix missing BLSTM model in package" change: the `.h5` model now ships, but the library that loads it is still undeclared, and the package fails even earlier — at import.

`openwillis-face` already declares `tensorflow==2.15.1` and `tf-keras==2.15.1` (it loads Keras `.h5` models the same way), and `openwillis-speech` / `openwillis-transcribe` both declare `tf-keras`. `openwillis-voice` is the only tensorflow-importing package that declares neither, so this change simply brings it in line with its siblings.

### Reproduction at current HEAD (3.2.x)

Building the wheel from `3.2.x` and inspecting its metadata shows no tensorflow/keras requirement:

```
$ cd openwillis-voice && python -m build --wheel
$ unzip -p dist/openwillis_voice-1.1.2-py3-none-any.whl '*/METADATA' | grep -Ei 'Requires-Dist.*(tensorflow|keras)'
(no output)
```

Importing the module that sits on the `import openwillis.voice` path, with every *declared* dependency satisfied (here stubbed so the only unmet import is the undeclared one), fails on tensorflow:

```
ModuleNotFoundError: No module named 'tensorflow'
```

### Verification of the fix

After adding the two lines, the rebuilt wheel declares them and the import clears the tensorflow line:

```
$ unzip -p dist/openwillis_voice-1.1.2-py3-none-any.whl '*/METADATA' | grep -Ei 'Requires-Dist.*(tensorflow|keras)'
Requires-Dist: tensorflow==2.15.1
Requires-Dist: tf-keras==2.15.1
```

The change is two lines in `openwillis-voice/requirements.txt` and touches no code, so it introduces no behavioral change; the pins match the versions already shipped and exercised by `openwillis-face`. The repository has no automated test suite, so verification is the artifact/import reproduction above rather than a regression test.

### How this was managed

I tracked this work on a live agile board that was imported from this repository's own issues and pull requests (223 stories, 6 labels), and used it to manage the fix. The specific story for this change is https://eastagiletracker.com/projects/329/stories/213784 and the full board is at https://eastagiletracker.com/projects/329.

![board](https://raw.githubusercontent.com/eastagiletracker/openwillis/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
